### PR TITLE
fix(CLI Templates): Move application start error to application.main …

### DIFF
--- a/packages/cli/generators/app/templates/index.js.ejs
+++ b/packages/cli/generators/app/templates/index.js.ejs
@@ -2,5 +2,8 @@ const application = (module.exports = require('./dist'));
 
 if (require.main === module) {
   // Run the application
-  application.main();
+  application.main().catch(err => {
+    console.log('Cannot start the application.', err);
+    process.exit(1);
+  });
 }

--- a/packages/cli/generators/app/templates/src/index.ts.ejs
+++ b/packages/cli/generators/app/templates/src/index.ts.ejs
@@ -5,12 +5,6 @@ export {<%= project.applicationName %>};
 
 export async function main(options?: ApplicationConfig) {
   const app = new <%= project.applicationName %>(options);
-
-  try {
-    await app.boot();
-    await app.start();
-  } catch (err) {
-    console.error(`Unable to start application: ${err}`);
-  }
+  await app.start();
   return app;
 }

--- a/packages/openapi-v3/package-lock.json
+++ b/packages/openapi-v3/package-lock.json
@@ -1,0 +1,34 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@types/debug": {
+			"version": "0.0.30",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
+			"integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
+		},
+		"@types/lodash": {
+			"version": "4.14.104",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
+			"integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ=="
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		}
+	}
+}


### PR DESCRIPTION
…and remove error handler from m

This is a fix for issue #925 which moves the the start error handler to the top-most caller instead
of being handled by main.

fix #925

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
