### PR TITLE
refactor(examples): move application start error catch

### DIFF
--- a/packages/cli/generators/app/templates/src/index.ts.ejs
+++ b/packages/cli/generators/app/templates/src/index.ts.ejs
@@ -6,5 +6,6 @@ export {<%= project.applicationName %>};
 export async function main(options?: ApplicationConfig) {
   const app = new <%= project.applicationName %>(options);
   await app.start();
+  await app.boot();
   return app;
 }

--- a/packages/example-getting-started/index.js
+++ b/packages/example-getting-started/index.js
@@ -7,5 +7,8 @@ const application = (module.exports = require('./dist'));
 
 if (require.main === module) {
   // Run the application
-  application.main();
+  application.main().catch(err => {
+    console.log('Cannot start the application.', err);
+    process.exit(1);
+  });
 }

--- a/packages/example-getting-started/src/index.ts
+++ b/packages/example-getting-started/src/index.ts
@@ -8,12 +8,8 @@ import {RestServer} from '@loopback/rest';
 
 export async function main() {
   const app = new TodoApplication();
-  try {
-    await app.boot();
-    await app.start();
-  } catch (err) {
-    console.error(`Unable to start application: ${err}`);
-  }
+  await app.boot();
+  await app.start();
   const server = await app.getServer(RestServer);
   console.log(`Server is running on port ${await server.get('rest.port')}`);
   return app;

--- a/packages/example-hello-world/index.js
+++ b/packages/example-hello-world/index.js
@@ -7,5 +7,8 @@ const application = (module.exports = require('./dist'));
 
 if (require.main === module) {
   // Run the application
-  application.main();
+  application.main().catch(err => {
+    console.log('Cannot start the application.', err);
+    process.exit(1);
+  });
 }

--- a/packages/example-hello-world/src/index.ts
+++ b/packages/example-hello-world/src/index.ts
@@ -7,10 +7,6 @@ import {HelloWorldApplication} from './application';
 
 export async function main() {
   const app = new HelloWorldApplication();
-  try {
-    await app.start();
-  } catch (err) {
-    console.error(`Unable to start application: ${err}`);
-  }
+  await app.start();
   return app;
 }

--- a/packages/example-rpc-server/index.js
+++ b/packages/example-rpc-server/index.js
@@ -7,5 +7,8 @@ const application = (module.exports = require('./dist'));
 
 if (require.main === module) {
   // Run the application
-  application.main();
+  application.main().catch(err => {
+    console.log('Cannot start the application.', err);
+    process.exit(1);
+  });
 }

--- a/packages/example-rpc-server/src/index.ts
+++ b/packages/example-rpc-server/src/index.ts
@@ -9,11 +9,7 @@ import {ApplicationConfig} from '@loopback/core';
 export async function main(options?: ApplicationConfig) {
   const app = new MyApplication(options);
 
-  try {
-    await app.start();
-  } catch (err) {
-    console.error(`Unable to start application: ${err}`);
-  }
+  await app.start();
   return app;
 }
 


### PR DESCRIPTION
A similar refactoring as in the CLI generator template is applied to the examples to complete the
fix for issue #925. Application start errors are now cached in the main index instead of the main function.

fix #925

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
